### PR TITLE
#5: Delegate VBOX restart to INNOSETUP

### DIFF
--- a/Boot2Docker.iss
+++ b/Boot2Docker.iss
@@ -157,7 +157,7 @@ var
 begin
     //MsgBox('installing vbox', mbInformation, MB_OK);
     WizardForm.FilenameLabel.Caption := 'installing VirtualBox'
-    if Exec(ExpandConstant('msiexec'), ExpandConstant('/qn /i "{app}\VirtualBox-4.3.12-r93733-MultiArch_amd64.msi"'), '', SW_HIDE,
+    if Exec(ExpandConstant('msiexec'), ExpandConstant('/qn /i "{app}\VirtualBox-4.3.12-r93733-MultiArch_amd64.msi" /norestart'), '', SW_HIDE,
        ewWaitUntilTerminated, ResultCode) then
     begin
       // handle success if necessary; ResultCode contains the exit code


### PR DESCRIPTION
Sometimes VBOX will automatically restart on a silent install. We should suppress this by default in the msiexec command since INNOSETUP will prompt for a restart in non-silent mode appropriately and we can control the restart of silent install in the normal way at the boot2docker-install.exe level ala 

```
boot2docker-instal.exe /SP /SILENT /VERYSILENT /SUPRESSMSGBOXES /NOCANCEL /NOREBOOT /NORESTART /CLOSEAPPLICATIONS /LOADINF="b2d.inf"'
```

There must be some weird end of line funk between unix and windows causing the entire replacement of this file but i wasn't able to get sublimetext to comply with whatever end of line usage is happening in this repo by default. The key line being changed is only

```
 -    if Exec(ExpandConstant('msiexec'), ExpandConstant('/qn /i "{app}\VirtualBox-4.3.12-r93733-MultiArch_amd64.msi"'), '', SW_HIDE,
+    if Exec(ExpandConstant('msiexec'), ExpandConstant('/qn /i "{app}\VirtualBox-4.3.12-r93733-MultiArch_amd64.msi" /norestart'), '', SW_HIDE,
```
