### PR TITLE
Delegate VBOX restart to INNOSETUP

### DIFF
--- a/Boot2Docker.iss
+++ b/Boot2Docker.iss
@@ -156,7 +156,7 @@ var
 begin
     //MsgBox('installing vbox', mbInformation, MB_OK);
     WizardForm.FilenameLabel.Caption := 'installing VirtualBox'
-    if Exec(ExpandConstant('msiexec'), ExpandConstant('/qn /i "{app}\VirtualBox-4.3.12-r93733-MultiArch_amd64.msi"'), '', SW_HIDE,
+    if Exec(ExpandConstant('msiexec'), ExpandConstant('/qn /i "{app}\VirtualBox-4.3.12-r93733-MultiArch_amd64.msi" /norestart'), '', SW_HIDE,
        ewWaitUntilTerminated, ResultCode) then
     begin
       // handle success if necessary; ResultCode contains the exit code


### PR DESCRIPTION
rebased #32

Sometimes VBOX will automatically restart on a silent install. We should suppress this by default in the msiexec command since INNOSETUP will prompt for a restart in non-silent mode appropriately and we can control the restart of silent install in the normal way at the boot2docker-install.exe level.
