### PR TITLE
Make start.sh start a shell instead of sshing VM

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -22,12 +22,14 @@ echo 'starting...'
 ./boot2docker.exe start
 echo
 
+echo 'IP address of docker VM:'
 ./boot2docker.exe ip
-
-echo 'connecting...'
-./boot2docker.exe ssh
 echo
 
+echo 'setting environment variables ...'
+./boot2docker.exe shellinit | sed  's,\\,\\\\,g' # eval swallows single backslashes in windows style path
+eval "$(./boot2docker.exe shellinit 2>/dev/null | sed  's,\\,\\\\,g')"
 echo
-echo '[Press any key to exit]'
-read
+
+cd
+exec "$BASH" --login -i


### PR DESCRIPTION
This change makes start.sh eval output of shellinit cmd and then start a
bash login shell (still can't find out a good way to override git's MOTD
without losing it, so no change there).

With this change clicking on "Boot2Docker Start" shortcut does the following:
![](http://cl.ly/image/051K093L101z/Image%202015-03-24%20at%201.45.58%20PM.png)
*(last cmd failing because we use b2d 1.5.0 iso)*

Signed-off-by: Ahmet Alp Balkan <ahmetalpbalkan@gmail.com>
cc: @tianon @SvenDowideit 