### PR TITLE
Add shortcut to SSH into boot2docker VM

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -31,5 +31,7 @@ echo 'setting environment variables ...'
 eval "$(./boot2docker.exe shellinit 2>/dev/null | sed  's,\\,\\\\,g')"
 echo
 
+echo 'You can now use `docker` directly, or `boot2docker ssh` to log into the VM.'
+
 cd
 exec "$BASH" --login -i


### PR DESCRIPTION
As the native Windows client is still young, preserve a link to easily SSH into the boot2docker VM as an alternative.

Ping @ahmetalpbalkan: is that ok for you?