### PR TITLE
Remove the call to clear, not all windows bash env's have it

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -e
 
-# clear the MSYS MOTD
-clear
-
 cd "$(dirname "$BASH_SOURCE")"
 
 ISO="$HOME/.boot2docker/boot2docker.iso"


### PR DESCRIPTION
Signed-off-by: Sven Dowideit SvenDowideit@home.org.au

closes #97

affects #102
