### PR TITLE
Fix for the missing variable environment HOME

### DIFF
--- a/Boot2Docker.iss
+++ b/Boot2Docker.iss
@@ -109,6 +109,16 @@ Name: "{group}\Delete Boot2Docker VM"; WorkingDir: "{app}"; Filename: "{app}\del
 [UninstallRun]
 Filename: "{app}\delete.sh"
 
+[UninstallDelete]
+Type: filesandordirs; Name: "{%HOME}\.boot2docker"
+Type: filesandordirs; Name: "{%USERPROFILE}\.boot2docker"
+
+Type: filesandordirs; Name: "{%HOME}\VirtualBox VMs\boot2docker-vm"
+Type: filesandordirs; Name: "{%USERPROFILE}\VirtualBox VMs\boot2docker-vm"
+
+Type: files; Name: "{%HOME}\.ssh\id_boot2docker.pub"
+Type: files; Name: "{%USERPROFILE}\.ssh\id_boot2docker.pub"
+
 [Code]
 var
 	restart: boolean;

--- a/delete.sh
+++ b/delete.sh
@@ -4,6 +4,8 @@ set -e
 # clear the MSYS MOTD
 clear
 
+if [ "$HOME" == "" ]; then export HOME=$USERPROFILE; fi
+
 cd "$(dirname "$BASH_SOURCE")"
 
 ( set -x; ./boot2docker.exe stop ) || true

--- a/start.sh
+++ b/start.sh
@@ -4,6 +4,8 @@ set -e
 # clear the MSYS MOTD
 clear
 
+if [ "$HOME" == "" ]; then export HOME=$USERPROFILE; fi
+
 cd "$(dirname "$BASH_SOURCE")"
 
 ISO="$HOME/.boot2docker/boot2docker.iso"


### PR DESCRIPTION
By default, Windows doesn't have the environment variable HOME used in the scripts.
This fix sets HOME with USERPROFILE if it's missing.
It also adds some cleanup for these files/folders that were still present after uninstall:
 $HOME.boot2docker
 $HOME.VirtualBox VMs\boot2docker-vm
 $HOME.ssh\id_boot2docker.pub
 $HOME.ssh\id_boot2docker.pub
